### PR TITLE
Change behavior of clean_case to be conservative

### DIFF
--- a/caelus/run/core.py
+++ b/caelus/run/core.py
@@ -121,6 +121,8 @@ def clean_polymesh(casedir,
 def clean_casedir(casedir,
                   preserve_extra=None,
                   preserve_zero=True,
+                  preserve_times=False,
+                  preserve_processors=False,
                   purge_mesh=False):
     """Clean a Caelus case directory.
 
@@ -135,6 +137,8 @@ def clean_casedir(casedir,
         preserve_extra (list): List of shell wildcard patterns to preserve
         purge_mesh (bool): If true, also removes mesh from constant/polyMesh
         preserve_zero (bool): If False, removes the 0 directory
+        preserve_times (bool): If False, removes the time directories
+        preserve_processors (bool): If False, removes processor directories
 
     Raises:
         IOError: ``clean_casedir`` will refuse to remove files from a directory
@@ -143,8 +147,12 @@ def clean_casedir(casedir,
     base_patterns = ["system", "constant", "*.yaml", "*.yml", "*.py",
                      "*.job", "README*", "readme*"]
     zero_pat = ["0"] if preserve_zero else []
+    time_pat = (["[1-9]*", "0.[0-9]*", "-[0-9]*"]
+                if preserve_times else [])
+    proc_pat = ["processor*"] if preserve_processors else []
     extra_pat = preserve_extra if preserve_extra else []
-    ppatterns = base_patterns + zero_pat + extra_pat
+    ppatterns = (base_patterns + zero_pat + extra_pat
+                 + time_pat + proc_pat)
 
     absdir = osutils.abspath(casedir)
     if not is_caelus_casedir(absdir):

--- a/caelus/run/tasks.py
+++ b/caelus/run/tasks.py
@@ -186,13 +186,19 @@ class Tasks(object):
 
     def cmd_clean_case(self, options):
         """Clean a case directory"""
-        remove_zero = options.get("remove_zero", False)
-        remove_mesh = options.get("remove_mesh", False)
+        purge_all = options.get("purge_all", False)
+        purge_generated = options.get("purge_generated", purge_all)
+        remove_zero = options.get("remove_zero", purge_all)
+        remove_mesh = options.get("remove_mesh", purge_all)
+        remove_times = options.get("remove_time_dirs", purge_generated)
+        remove_processors = options.get("remove_processor", purge_generated)
         preserve_extra = options.get("preserve", None)
         remove_extra = options.get("remove_extra", None)
         _lgr.info("Cleaning case directory: %s", self.case_dir)
         run_cmds.clean_casedir(self.case_dir,
                                preserve_zero=(not remove_zero),
+                               preserve_times=(not remove_times),
+                               preserve_processors=(not remove_processors),
                                purge_mesh=remove_mesh,
                                preserve_extra=preserve_extra)
         if remove_extra:

--- a/caelus/scripts/caelus.py
+++ b/caelus/scripts/caelus.py
@@ -273,10 +273,16 @@ class CaelusCmd(CaelusSubCmdScript):
             help="path to the case directory")
         clean.add_argument(
             '-m', '--clean-mesh', action='store_true',
-            help="remove polyMesh directory")
+            help="remove polyMesh directory (default: no)")
         clean.add_argument(
             '-z', '--clean-zero', action='store_true',
-            help="remove 0 directory")
+            help="remove 0 directory (default: no)")
+        clean.add_argument(
+            '-t', '--clean-time-dirs', action='store_true',
+            help="remove time directories (default: no)")
+        clean.add_argument(
+            '--clean-processors', action='store_true',
+            help="clean processor directories (default: no)")
         clean.add_argument(
             '-p', '--preserve', action='append',
             help="shell wildcard patterns of extra files to preserve")
@@ -443,8 +449,12 @@ class CaelusCmd(CaelusSubCmdScript):
         args = self.args
         purge_mesh = args.clean_mesh
         preserve_zero = (not args.clean_zero)
+        preserve_times = (not args.clean_time_dirs)
+        preserve_processors = (not args.clean_processors)
         clean_casedir(args.case_dir,
                       preserve_zero=preserve_zero,
+                      preserve_times=preserve_times,
+                      preserve_processors=preserve_processors,
                       purge_mesh=purge_mesh,
                       preserve_extra=args.preserve)
         _lgr.info("Cleaned case directory successfully.")


### PR DESCRIPTION
- Add options to preserve time and processor directories

- Add remove_times, remove_processors, purge_all, purge_generated to
  "clean_case" task

- Add command line options to "caelus clean" command.